### PR TITLE
Add Multi-Database-Schema Support and Improved Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ uv.lock
 src/mcp_snowflake_server/__pycache__
 **/.DS_Store
 # dist
-src/temp_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ uv.lock
 src/mcp_snowflake_server/__pycache__
 **/.DS_Store
 # dist
+src/temp_*.py

--- a/README.md
+++ b/README.md
@@ -18,111 +18,91 @@ The server offers six core tools:
 
 #### Query Tools
 - `read_query`
-   - Execute SELECT queries to read data from the database
-   - Input:
-     - `query` (string): The SELECT SQL query to execute
-   - Returns: Query results as array of objects
+  - Execute SELECT queries to read data from the database
+  - Input:
+    - `query` (string): The SELECT SQL query to execute
+  - Returns: Query results as array of objects
 
 - `write_query` (with `--allow-write` flag)
-   - Execute INSERT, UPDATE, or DELETE queries
-   - Input:
-     - `query` (string): The SQL modification query
-   - Returns: `{ affected_rows: number }`
+  - Execute INSERT, UPDATE, or DELETE queries
+  - Input:
+    - `query` (string): The SQL modification query
+  - Returns: `{ affected_rows: number }`
 
 - `create_table` (with `--allow-write` flag)
-   - Create new tables in the database
-   - Input:
-     - `query` (string): CREATE TABLE SQL statement
-   - Returns: Confirmation of table creation
+  - Create new tables in the database
+  - Input:
+    - `query` (string): CREATE TABLE SQL statement
+  - Returns: Confirmation of table creation
 
 #### Schema Tools
+- `list_databases`
+  - Get a list of all databases in the Snowflake instance.
+  - No input required
+  - Returns: Array of database names.
+
+- `list_schemas`
+  - Get a list of all schemas in a specific database.
+  - Input:
+    - `database` (string): Name of the database.
+  - Returns: Array of schema names.
+
 - `list_tables`
-   - Get a list of all tables in the database
-   - No input required
-   - Returns: Array of table names
+  - Get a list of all tables in a specific database and schema.
+  - Input:
+    - `database` (string): Name of the database.
+    - `schema` (string): Name of the schema.
+  - Returns: Array of table metadata.
 
 - `describe-table`
-   - View column information for a specific table
-   - Input:
-     - `table_name` (string): Name of table to describe (can be fully qualified)
-   - Returns: Array of column definitions with names and types
+  - View column information for a specific table
+  - Input:
+    - `table_name` (string): Fully qualified name of table to describe (e.g., `database.schema.table`)
+  - Returns: Array of column definitions with names and types
 
 #### Analysis Tools
 - `append_insight`
-   - Add new data insights to the memo resource
-   - Input:
-     - `insight` (string): data insight discovered from analysis
-   - Returns: Confirmation of insight addition
-   - Triggers update of memo://insights resource
+  - Add new data insights to the memo resource
+  - Input:
+    - `insight` (string): data insight discovered from analysis
+  - Returns: Confirmation of insight addition
+  - Triggers update of memo://insights resource
 
 
-## Usage with Claude Desktop
+## Usage with Claude Desktop Locally
 
-### Installing via Smithery
+1. Install [Claude AI Desktop App](https://claude.ai/download)
 
-To install Snowflake Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp_snowflake_server):
-
-```bash
-npx -y @smithery/cli install mcp_snowflake_server --client claude
+2. Install `uv` by:
+```
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### Installing via UVX
-
-```python
-# Add the server to your claude_desktop_config.json
-"mcpServers": {
-  "snowflake_pip": {
-      "command": "uvx",
-      "args": [
-          "mcp_snowflake_server",
-          "--account",
-          "the_account",
-          "--warehouse",
-          "the_warehouse",
-          "--user",
-          "the_user",
-          "--password",
-          "their_password",
-          "--role",
-          "the_role"
-          "--database",
-          "the_database",
-          "--schema",
-          "the_schema",
-          # Optionally: "--allow_write" (but not recommended)
-          # Optionally: "--log_dir", "/absolute/path/to/logs"
-          # Optionally: "--log_level", "DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"
-          # Optionally: "--exclude_tools", "{tool name}", ["{other tool name}"]
-      ]
-  }
-}
+3. Create a `.env` file using the following template under this dir
+```
+SNOWFLAKE_USER="XXX@EMAIL.COM"
+SNOWFLAKE_ACCOUNT="XXX"
+SNOWFLAKE_ROLE="XXX"
+SNOWFLAKE_DATABASE="XXX" # This doesn't affect the MCP's access scope
+SNOWFLAKE_SCHEMA="XXX"   # This doesn't affect the MCP's access scope
+SNOWFLAKE_WAREHOUSE="XXX"
+SNOWFLAKE_AUTHENTICATOR="externalbrowser"
+```
+4. Test locally using 
+```
+uv --directory /absolute/path/to/mcp_snowflake_server run mcp_snowflake_server
 ```
 
-### Installing locally
+5. Add the server to your `claude_desktop_config.json`
 ```python
-# Add the server to your claude_desktop_config.json
 "mcpServers": {
   "snowflake_local": {
-      "command": "uv",
+      "command": "/absolute/path/to/uv", # obtained by using `which uv`
       "args": [
           "--directory",
           "/absolute/path/to/mcp_snowflake_server",
           "run",
           "mcp_snowflake_server",
-          "--account",
-          "the_account",
-          "--warehouse",
-          "the_warehouse",
-          "--user",
-          "the_user",
-          "--password",
-          "their_password",
-          "--role",
-          "the_role"
-          "--database",
-          "the_database",
-          "--schema",
-          "the_schema",
           # Optionally: "--allow_write" (but not recommended)
           # Optionally: "--log_dir", "/absolute/path/to/logs"
           # Optionally: "--log_level", "DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ SNOWFLAKE_DATABASE="XXX" # This doesn't affect the MCP's access scope
 SNOWFLAKE_SCHEMA="XXX"   # This doesn't affect the MCP's access scope
 SNOWFLAKE_WAREHOUSE="XXX"
 SNOWFLAKE_PASSWORD="XXX"
+# Alternatively, you can use external browser for authentication without specifying the password
 # SNOWFLAKE_AUTHENTICATOR="externalbrowser" 
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The server offers six core tools:
 
 ## Usage Locally with Claude Desktop
 
-An full-version guide can be found [here](https://modelcontextprotocol.io/quickstart/user). Below is a quick guide to get started:
+Below is a quick guide to get started, and a more general and detailed guide can be found [here](https://modelcontextprotocol.io/quickstart/user). 
 
 
 1. Install [Claude AI Desktop App](https://claude.ai/download)

--- a/README.md
+++ b/README.md
@@ -85,18 +85,21 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 SNOWFLAKE_USER="XXX@EMAIL.COM"
 SNOWFLAKE_ACCOUNT="XXX"
-SNOWFLAKE_ROLE="XXX"
+SNOWFLAKE_ROLE="XXX"     # This determines the access scope of the MCP
 SNOWFLAKE_DATABASE="XXX" # This doesn't affect the MCP's access scope
 SNOWFLAKE_SCHEMA="XXX"   # This doesn't affect the MCP's access scope
 SNOWFLAKE_WAREHOUSE="XXX"
-SNOWFLAKE_AUTHENTICATOR="externalbrowser"
+SNOWFLAKE_AUTHENTICATOR="externalbrowser"  # Use Okta for authentication
 ```
-4. Test locally using 
+
+4. [Optional] Modify the `exclude_patterns` in `runtime_config.json` to filter out the resources you want to exclude.
+   
+5. Test locally using 
 ```
 uv --directory /absolute/path/to/mcp_snowflake_server run mcp_snowflake_server
 ```
 
-5. Add the server to your `claude_desktop_config.json`
+6. Add the server to your `claude_desktop_config.json` (Claude -> Settings -> Developer -> Edit Config)
 ```python
 "mcpServers": {
   "snowflake_local": {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ The server offers six core tools:
   - Triggers update of memo://insights resource
 
 
-## Usage with Claude Desktop Locally
+## Usage Locally with Claude Desktop
+
+An full-version guide can be found [here](https://modelcontextprotocol.io/quickstart/user). Below is a quick guide to get started:
+
 
 1. Install [Claude AI Desktop App](https://claude.ai/download)
 

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ The server offers six core tools:
 
 #### Query Tools
 - `read_query`
-  - Execute SELECT queries to read data from the database
-  - Input:
-    - `query` (string): The SELECT SQL query to execute
-  - Returns: Query results as array of objects
+   - Execute SELECT queries to read data from the database
+   - Input:
+     - `query` (string): The SELECT SQL query to execute
+   - Returns: Query results as array of objects
 
 - `write_query` (with `--allow-write` flag)
-  - Execute INSERT, UPDATE, or DELETE queries
-  - Input:
-    - `query` (string): The SQL modification query
-  - Returns: `{ affected_rows: number }`
+   - Execute INSERT, UPDATE, or DELETE queries
+   - Input:
+     - `query` (string): The SQL modification query
+   - Returns: `{ affected_rows: number }`
 
 - `create_table` (with `--allow-write` flag)
-  - Create new tables in the database
-  - Input:
-    - `query` (string): CREATE TABLE SQL statement
-  - Returns: Confirmation of table creation
+   - Create new tables in the database
+   - Input:
+     - `query` (string): CREATE TABLE SQL statement
+   - Returns: Confirmation of table creation
 
 #### Schema Tools
 - `list_databases`
@@ -55,24 +55,63 @@ The server offers six core tools:
   - Returns: Array of table metadata.
 
 - `describe-table`
-  - View column information for a specific table
-  - Input:
-    - `table_name` (string): Fully qualified name of table to describe (e.g., `database.schema.table`)
-  - Returns: Array of column definitions with names and types
+   - View column information for a specific table
+   - Input:
+     - `table_name` (string): Name of table to describe (can be fully qualified)
+   - Returns: Array of column definitions with names and types
 
 #### Analysis Tools
 - `append_insight`
-  - Add new data insights to the memo resource
-  - Input:
-    - `insight` (string): data insight discovered from analysis
-  - Returns: Confirmation of insight addition
-  - Triggers update of memo://insights resource
+   - Add new data insights to the memo resource
+   - Input:
+     - `insight` (string): data insight discovered from analysis
+   - Returns: Confirmation of insight addition
+   - Triggers update of memo://insights resource
 
 
-## Usage Locally with Claude Desktop
+## Usage with Claude Desktop
 
-Below is a quick guide to get started, and a more general and detailed guide can be found [here](https://modelcontextprotocol.io/quickstart/user). 
+### Installing via Smithery
 
+To install Snowflake Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp_snowflake_server):
+
+```bash
+npx -y @smithery/cli install mcp_snowflake_server --client claude
+```
+
+### Installing via UVX 
+
+```python
+# Add the server to your claude_desktop_config.json (Claude -> Settings -> Developer -> Edit Config)
+"mcpServers": {
+  "snowflake_pip": {
+      "command": "uvx",
+      "args": [
+          "mcp_snowflake_server",
+          "--account",
+          "the_account",
+          "--warehouse",
+          "the_warehouse",
+          "--user",
+          "the_user",
+          "--password",
+          "their_password",
+          "--role",
+          "the_role"
+          "--database",
+          "the_database",
+          "--schema",
+          "the_schema",
+          # Optionally: "--allow_write" (but not recommended)
+          # Optionally: "--log_dir", "/absolute/path/to/logs"
+          # Optionally: "--log_level", "DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"
+          # Optionally: "--exclude_tools", "{tool name}", ["{other tool name}"]
+      ]
+  }
+}
+```
+
+### Installing locally
 
 1. Install [Claude AI Desktop App](https://claude.ai/download)
 
@@ -89,7 +128,8 @@ SNOWFLAKE_ROLE="XXX"     # This determines the access scope of the MCP
 SNOWFLAKE_DATABASE="XXX" # This doesn't affect the MCP's access scope
 SNOWFLAKE_SCHEMA="XXX"   # This doesn't affect the MCP's access scope
 SNOWFLAKE_WAREHOUSE="XXX"
-SNOWFLAKE_AUTHENTICATOR="externalbrowser"  # Use Okta for authentication
+SNOWFLAKE_PASSWORD="XXX"
+# SNOWFLAKE_AUTHENTICATOR="externalbrowser" 
 ```
 
 4. [Optional] Modify the `exclude_patterns` in `runtime_config.json` to filter out the resources you want to exclude.

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -1,0 +1,32 @@
+{
+  "exclude_patterns": {
+    "databases": [
+      "build",
+      "ci",
+      "backup",
+      "temp",
+      "test",
+      "dev"
+    ],
+    "schemas": [
+      "backup",
+      "back_up",
+      "temp",
+      "tmp",
+      "test",
+      "staging",
+      "util",
+      "information_schema"
+    ],
+    "tables": [
+      "backup",
+      "bak",
+      "tmp",
+      "temp",
+      "test",
+      "copy",
+      "old",
+      "archive"
+    ]
+  }
+}

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -1,32 +1,14 @@
 {
   "exclude_patterns": {
     "databases": [
-      "build",
-      "ci",
-      "backup",
-      "temp",
-      "test",
-      "dev"
+      "temp"
     ],
     "schemas": [
-      "backup",
-      "back_up",
       "temp",
-      "tmp",
-      "test",
-      "staging",
-      "util",
       "information_schema"
     ],
     "tables": [
-      "backup",
-      "bak",
-      "tmp",
-      "temp",
-      "test",
-      "copy",
-      "old",
-      "archive"
+      "temp"
     ]
   }
 }

--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -98,6 +98,7 @@ def main():
             connection_args=connection_args,
             allow_write=server_args["allow_write"],
             log_dir=server_args["log_dir"],
+            prefetch=server_args["prefetch"],
             log_level=server_args["log_level"],
             exclude_tools=server_args["exclude_tools"],
         )

--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -88,17 +88,16 @@ def main():
 
     assert (
         "database" in connection_args
-    ), 'You must provide the account identifier as "--database" argument or "SNOWFLAKE_DATABASE" environment variable. This MCP server can only operate on a single database.'
+    ), 'You must provide the account identifier as "--database" argument or "SNOWFLAKE_DATABASE" environment variable.'
     assert (
         "schema" in connection_args
-    ), 'You must provide the username as "--schema" argument or "SNOWFLAKE_SCHEMA" environment variable. This MCP server can only operate on a single schema.'
+    ), 'You must provide the username as "--schema" argument or "SNOWFLAKE_SCHEMA" environment variable.'
 
     asyncio.run(
         server.main(
             connection_args=connection_args,
             allow_write=server_args["allow_write"],
             log_dir=server_args["log_dir"],
-            prefetch=server_args["prefetch"],
             log_level=server_args["log_level"],
             exclude_tools=server_args["exclude_tools"],
         )

--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -21,7 +21,7 @@ def parse_args():
         "--prefetch",
         action="store_true",
         dest="prefetch",
-        default=True,
+        default=False,
         help="Prefetch table descriptions (when enabled, list_tables and describe_table are disabled)",
     )
     parser.add_argument(

--- a/src/mcp_snowflake_server/server.py
+++ b/src/mcp_snowflake_server/server.py
@@ -42,14 +42,18 @@ class SnowflakeDB:
     def _init_database(self):
         """Initialize connection to the Snowflake database"""
         try:
+            # Create session without setting specific database and schema
             self.session = Session.builder.configs(self.connection_config).create()
-            for component in ["database", "schema", "warehouse"]:
-                self.session.sql(f"USE {component.upper()} {self.connection_config[component].upper()}")
+
+            # Set initial warehouse if provided, but don't set database or schema
+            if "warehouse" in self.connection_config:
+                self.session.sql(f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}")
+
             self.auth_time = time.time()
         except Exception as e:
             raise ValueError(f"Failed to connect to Snowflake database: {e}")
 
-    def execute_query(self, query: str) -> list[dict[str, Any]]:
+    def execute_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
         """Execute a SQL query and return results as a list of dictionaries"""
         if not self.session or time.time() - self.auth_time > self.AUTH_EXPIRATION_TIME:
             self._init_database()
@@ -103,18 +107,31 @@ class Tool(BaseModel):
     name: str
     description: str
     input_schema: dict[str, Any]
-    handler: Callable[[str, dict[str, Any] | None], list[types.TextContent | types.ImageContent | types.EmbeddedResource]]
+    handler: Callable[
+        [str, dict[str, Any] | None],
+        list[types.TextContent | types.ImageContent | types.EmbeddedResource],
+    ]
     tags: list[str] = []
 
 
 # Tool handlers
-async def handle_list_tables(arguments, db, *_):
-    query = f"""
-        SELECT table_catalog, table_schema, table_name, comment 
-        FROM {db.connection_config['database']}.information_schema.tables 
-        WHERE table_schema = '{db.connection_config['schema'].upper()}'
-    """
+async def handle_list_databases(arguments, db, *_, exclusion_config=None):
+    query = "SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES"
     data, data_id = db.execute_query(query)
+
+    # Filter out excluded databases
+    if exclusion_config and "databases" in exclusion_config and exclusion_config["databases"]:
+        filtered_data = []
+        for item in data:
+            db_name = item.get("DATABASE_NAME", "")
+            exclude = False
+            for pattern in exclusion_config["databases"]:
+                if pattern.lower() in db_name.lower():
+                    exclude = True
+                    break
+            if not exclude:
+                filtered_data.append(item)
+        data = filtered_data
 
     output = {
         "type": "data",
@@ -127,7 +144,98 @@ async def handle_list_tables(arguments, db, *_):
         types.TextContent(type="text", text=yaml_output),
         types.EmbeddedResource(
             type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
+            resource=types.TextResourceContents(
+                uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+            ),
+        ),
+    ]
+
+
+async def handle_list_schemas(arguments, db, *_, exclusion_config=None):
+    if not arguments or "database" not in arguments:
+        raise ValueError("Missing required 'database' parameter")
+
+    database = arguments["database"]
+    query = f"SELECT SCHEMA_NAME FROM {database.upper()}.INFORMATION_SCHEMA.SCHEMATA"
+    data, data_id = db.execute_query(query)
+
+    # Filter out excluded schemas
+    if exclusion_config and "schemas" in exclusion_config and exclusion_config["schemas"]:
+        filtered_data = []
+        for item in data:
+            schema_name = item.get("SCHEMA_NAME", "")
+            exclude = False
+            for pattern in exclusion_config["schemas"]:
+                if pattern.lower() in schema_name.lower():
+                    exclude = True
+                    break
+            if not exclude:
+                filtered_data.append(item)
+        data = filtered_data
+
+    output = {
+        "type": "data",
+        "data_id": data_id,
+        "database": database,
+        "data": data,
+    }
+    yaml_output = data_to_yaml(output)
+    json_output = json.dumps(output)
+    return [
+        types.TextContent(type="text", text=yaml_output),
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.TextResourceContents(
+                uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+            ),
+        ),
+    ]
+
+
+async def handle_list_tables(arguments, db, *_, exclusion_config=None):
+    if not arguments or "database" not in arguments or "schema" not in arguments:
+        raise ValueError("Missing required 'database' and 'schema' parameters")
+
+    database = arguments["database"]
+    schema = arguments["schema"]
+
+    query = f"""
+        SELECT table_catalog, table_schema, table_name, comment 
+        FROM {database}.information_schema.tables 
+        WHERE table_schema = '{schema.upper()}'
+    """
+    data, data_id = db.execute_query(query)
+
+    # Filter out excluded tables
+    if exclusion_config and "tables" in exclusion_config and exclusion_config["tables"]:
+        filtered_data = []
+        for item in data:
+            table_name = item.get("TABLE_NAME", "")
+            exclude = False
+            for pattern in exclusion_config["tables"]:
+                if pattern.lower() in table_name.lower():
+                    exclude = True
+                    break
+            if not exclude:
+                filtered_data.append(item)
+        data = filtered_data
+
+    output = {
+        "type": "data",
+        "data_id": data_id,
+        "database": database,
+        "schema": schema,
+        "data": data,
+    }
+    yaml_output = data_to_yaml(output)
+    json_output = json.dumps(output)
+    return [
+        types.TextContent(type="text", text=yaml_output),
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.TextResourceContents(
+                uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+            ),
         ),
     ]
 
@@ -136,10 +244,16 @@ async def handle_describe_table(arguments, db, *_):
     if not arguments or "table_name" not in arguments:
         raise ValueError("Missing table_name argument")
 
-    split_identifier = arguments["table_name"].split(".")
-    table_name = split_identifier[-1].upper()
-    schema_name = (split_identifier[-2] if len(split_identifier) > 1 else db.connection_config["schema"]).upper()
-    database_name = (split_identifier[-3] if len(split_identifier) > 2 else db.connection_config["database"]).upper()
+    table_spec = arguments["table_name"]
+    split_identifier = table_spec.split(".")
+
+    # Parse the fully qualified table name
+    if len(split_identifier) < 3:
+        raise ValueError("Table name must be fully qualified as 'database.schema.table'")
+
+    database_name = split_identifier[0].upper()
+    schema_name = split_identifier[1].upper()
+    table_name = split_identifier[2].upper()
 
     query = f"""
         SELECT column_name, column_default, is_nullable, data_type, comment 
@@ -151,6 +265,9 @@ async def handle_describe_table(arguments, db, *_):
     output = {
         "type": "data",
         "data_id": data_id,
+        "database": database_name,
+        "schema": schema_name,
+        "table": table_name,
         "data": data,
     }
     yaml_output = data_to_yaml(output)
@@ -159,14 +276,20 @@ async def handle_describe_table(arguments, db, *_):
         types.TextContent(type="text", text=yaml_output),
         types.EmbeddedResource(
             type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
+            resource=types.TextResourceContents(
+                uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+            ),
         ),
     ]
 
 
 async def handle_read_query(arguments, db, write_detector, *_):
+    if not arguments or "query" not in arguments:
+        raise ValueError("Missing query argument")
+
     if write_detector.analyze_query(arguments["query"])["contains_write"]:
         raise ValueError("Calls to read_query should not contain write operations")
+
     data, data_id = db.execute_query(arguments["query"])
     output = {
         "type": "data",
@@ -179,7 +302,9 @@ async def handle_read_query(arguments, db, write_detector, *_):
         types.TextContent(type="text", text=yaml_output),
         types.EmbeddedResource(
             type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
+            resource=types.TextResourceContents(
+                uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+            ),
         ),
     ]
 
@@ -213,93 +338,128 @@ async def handle_create_table(arguments, db, _, allow_write, __):
     return [types.TextContent(type="text", text=f"Table created successfully. data_id = {data_id}")]
 
 
-async def prefetch_tables(db: SnowflakeDB, credentials: dict) -> dict:
-    """Prefetch table and column information"""
-    try:
-        logger.info("Prefetching table descriptions")
-        table_results, data_id = db.execute_query(
-            f"""SELECT table_name, comment 
-                FROM {credentials['database']}.information_schema.tables 
-                WHERE table_schema = '{credentials['schema'].upper()}'"""
-        )
-
-        column_results, data_id = db.execute_query(
-            f"""SELECT table_name, column_name, data_type, comment 
-                FROM {credentials['database']}.information_schema.columns 
-                WHERE table_schema = '{credentials['schema'].upper()}'"""
-        )
-
-        tables_brief = {}
-        for row in table_results:
-            tables_brief[row["TABLE_NAME"]] = {**row, "COLUMNS": {}}
-
-        for row in column_results:
-            row_without_table_name = row.copy()
-            del row_without_table_name["TABLE_NAME"]
-            tables_brief[row["TABLE_NAME"]]["COLUMNS"][row["COLUMN_NAME"]] = row_without_table_name
-
-        return tables_brief
-
-    except Exception as e:
-        logger.error(f"Error prefetching table descriptions: {e}")
-        return f"Error prefetching table descriptions: {e}"
-
-
 async def main(
     allow_write: bool = False,
     connection_args: dict = None,
     log_dir: str = None,
-    prefetch: bool = False,
     log_level: str = "INFO",
     exclude_tools: list[str] = [],
+    config_file: str = "runtime_config.json",
+    exclude_patterns: dict = None,
 ):
     # Setup logging
     if log_dir:
         os.makedirs(log_dir, exist_ok=True)
-        logger.handlers.append(logging.FileHandler(os.path.join(log_dir, "mcp_snowflake_server.log")))
+        logger.handlers.append(
+            logging.FileHandler(os.path.join(log_dir, "mcp_snowflake_server.log"))
+        )
     if log_level:
         logger.setLevel(log_level)
 
     logger.info("Starting Snowflake MCP Server")
     logger.info("Allow write operations: %s", allow_write)
-    logger.info("Prefetch table descriptions: %s", prefetch)
     logger.info("Excluded tools: %s", exclude_tools)
+
+    # Load configuration from file if provided
+    config = {}
+    #
+    if config_file:
+        try:
+            with open(config_file, "r") as f:
+                config = json.load(f)
+                logger.info(f"Loaded configuration from {config_file}")
+        except Exception as e:
+            logger.error(f"Error loading configuration file: {e}")
+
+    # Merge exclude_patterns from parameters with config file
+    exclusion_config = config.get("exclude_patterns", {})
+    if exclude_patterns:
+        # Merge patterns from parameters with those from config file
+        for key, patterns in exclude_patterns.items():
+            if key in exclusion_config:
+                exclusion_config[key].extend(patterns)
+            else:
+                exclusion_config[key] = patterns
+
+    # Set default patterns if none are specified
+    if not exclusion_config:
+        exclusion_config = {"databases": [], "schemas": [], "tables": []}
+
+    # Ensure all keys exist in the exclusion config
+    for key in ["databases", "schemas", "tables"]:
+        if key not in exclusion_config:
+            exclusion_config[key] = []
+
+    logger.info(f"Exclusion patterns: {exclusion_config}")
 
     db = SnowflakeDB(connection_args)
     server = Server("snowflake-manager")
     write_detector = SQLWriteDetector()
 
-    tables_info = (await prefetch_tables(db, connection_args)) if prefetch else {}
-    tables_brief = data_to_yaml(tables_info) if prefetch else ""
+    tables_info = {}
+    tables_brief = ""
 
     all_tools = [
         Tool(
-            name="list_tables",
-            description="List all tables in the Snowflake database",
+            name="list_databases",
+            description="List all available databases in Snowflake",
             input_schema={
                 "type": "object",
                 "properties": {},
             },
+            handler=handle_list_databases,
+        ),
+        Tool(
+            name="list_schemas",
+            description="List all schemas in a database",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "database": {
+                        "type": "string",
+                        "description": "Database name to list schemas from",
+                    },
+                },
+                "required": ["database"],
+            },
+            handler=handle_list_schemas,
+        ),
+        Tool(
+            name="list_tables",
+            description="List all tables in a specific database and schema",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "database": {"type": "string", "description": "Database name"},
+                    "schema": {"type": "string", "description": "Schema name"},
+                },
+                "required": ["database", "schema"],
+            },
             handler=handle_list_tables,
-            tags=["description"],
         ),
         Tool(
             name="describe_table",
             description="Get the schema information for a specific table",
             input_schema={
                 "type": "object",
-                "properties": {"table_name": {"type": "string", "description": "Name of the table to describe"}},
+                "properties": {
+                    "table_name": {
+                        "type": "string",
+                        "description": "Fully qualified table name in the format 'database.schema.table'",
+                    },
+                },
                 "required": ["table_name"],
             },
             handler=handle_describe_table,
-            tags=["description"],
         ),
         Tool(
             name="read_query",
             description="Execute a SELECT query.",
             input_schema={
                 "type": "object",
-                "properties": {"query": {"type": "string", "description": "SELECT SQL query to execute"}},
+                "properties": {
+                    "query": {"type": "string", "description": "SELECT SQL query to execute"}
+                },
                 "required": ["query"],
             },
             handler=handle_read_query,
@@ -309,7 +469,12 @@ async def main(
             description="Add a data insight to the memo",
             input_schema={
                 "type": "object",
-                "properties": {"insight": {"type": "string", "description": "Data insight discovered from analysis"}},
+                "properties": {
+                    "insight": {
+                        "type": "string",
+                        "description": "Data insight discovered from analysis",
+                    }
+                },
                 "required": ["insight"],
             },
             handler=handle_append_insight,
@@ -331,7 +496,9 @@ async def main(
             description="Create a new table in the Snowflake database",
             input_schema={
                 "type": "object",
-                "properties": {"query": {"type": "string", "description": "CREATE TABLE SQL statement"}},
+                "properties": {
+                    "query": {"type": "string", "description": "CREATE TABLE SQL statement"}
+                },
                 "required": ["query"],
             },
             handler=handle_create_table,
@@ -342,10 +509,10 @@ async def main(
     exclude_tags = []
     if not allow_write:
         exclude_tags.append("write")
-    if prefetch:
-        exclude_tags.append("description")
     allowed_tools = [
-        tool for tool in all_tools if tool.name not in exclude_tools and not any(tag in exclude_tags for tag in tool.tags)
+        tool
+        for tool in all_tools
+        if tool.name not in exclude_tools and not any(tag in exclude_tags for tag in tool.tags)
     ]
 
     logger.info("Allowed tools: %s", [tool.name for tool in allowed_tools])
@@ -391,7 +558,9 @@ async def main(
         return []
 
     @server.get_prompt()
-    async def handle_get_prompt(name: str, arguments: dict[str, str] | None) -> types.GetPromptResult:
+    async def handle_get_prompt(
+        name: str, arguments: dict[str, str] | None
+    ) -> types.GetPromptResult:
         raise ValueError(f"Unknown prompt: {name}")
 
     @server.call_tool()
@@ -400,13 +569,28 @@ async def main(
         name: str, arguments: dict[str, Any] | None
     ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
         if name in exclude_tools:
-            return [types.TextContent(type="text", text=f"Tool {name} is excluded from this data connection")]
+            return [
+                types.TextContent(
+                    type="text", text=f"Tool {name} is excluded from this data connection"
+                )
+            ]
 
         handler = next((tool.handler for tool in allowed_tools if tool.name == name), None)
         if not handler:
             raise ValueError(f"Unknown tool: {name}")
 
-        return await handler(arguments, db, write_detector, allow_write, server)
+        # Pass exclusion_config to the handler if it's a listing function
+        if name in ["list_databases", "list_schemas", "list_tables"]:
+            return await handler(
+                arguments,
+                db,
+                write_detector,
+                allow_write,
+                server,
+                exclusion_config=exclusion_config,
+            )
+        else:
+            return await handler(arguments, db, write_detector, allow_write, server)
 
     @server.list_tools()
     async def handle_list_tools() -> list[types.Tool]:


### PR DESCRIPTION
This pull request enhances the `mcp_snowflake_server` project:

## Main Change:
* Expanded from handling a single database/schema to multiple databases&schemas.

### Toolset Enhancements:
* Added handlers for listing databases, schemas, and tables 

### Configuration and Filtering:
* Added `runtime_config.json` to support exclusion patterns for databases, schemas, and tables.

### Authentication with `externalbrowser` 
* Added more guidance for local integration, and updated the `README` file for the Snowflake connection template to allow `externalbrowser` auth for local run.