### PR TITLE
feat: Add --exclude-json-results to reduce context window usage

### DIFF
--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -76,6 +76,13 @@ def parse_args():
         nargs="+",
         help="List of tools to exclude",
     )
+    parser.add_argument(
+        "--exclude-json-results",
+        action="store_true",
+        dest="exclude_json_results",
+        default=False,
+        help="Exclude JSON output from results",
+    )
     
     parser.add_argument(
         "--private_key_path",
@@ -123,6 +130,7 @@ def parse_args():
         "log_level": args.log_level,
         "prefetch": args.prefetch,
         "exclude_tools": args.exclude_tools,
+        "exclude_json_results": args.exclude_json_results,
         "connection_name": getattr(args, 'connection_name', None),
         "connections_file": getattr(args, 'connections_file', None),
     }
@@ -189,6 +197,7 @@ def main():
             prefetch=server_args["prefetch"],
             log_level=server_args["log_level"],
             exclude_tools=server_args["exclude_tools"],
+            exclude_json_results=server_args["exclude_json_results"],
         )
     )
 

--- a/src/mcp_snowflake_server/server.py
+++ b/src/mcp_snowflake_server/server.py
@@ -15,6 +15,8 @@ from .db_client import SnowflakeDB
 from .write_detector import SQLWriteDetector
 from .serialization import to_yaml, to_json
 
+ResponseType = types.TextContent | types.ImageContent | types.EmbeddedResource
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -43,15 +45,12 @@ class Tool(BaseModel):
     name: str
     description: str
     input_schema: dict[str, Any]
-    handler: Callable[
-        [str, dict[str, Any] | None],
-        list[types.TextContent | types.ImageContent | types.EmbeddedResource],
-    ]
+    handler: Callable[[str, dict[str, Any] | None], list[ResponseType]]
     tags: list[str] = []
 
 
 # Tool handlers
-async def handle_list_databases(arguments, db, *_, exclusion_config=None):
+async def handle_list_databases(arguments, db, *_, exclusion_config=None, exclude_json_results=False):
     query = "SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES"
     data, data_id = await db.execute_query(query)
 
@@ -76,16 +75,20 @@ async def handle_list_databases(arguments, db, *_, exclusion_config=None):
     }
     yaml_output = to_yaml(output)
     json_output = to_json(output)
-    return [
-        types.TextContent(type="text", text=yaml_output),
-        types.EmbeddedResource(
-            type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
-        ),
-    ]
+    results: list[ResponseType] = [types.TextContent(type="text", text=yaml_output)]
+    if not exclude_json_results:
+        results.append(
+            types.EmbeddedResource(
+                type="resource",
+                resource=types.TextResourceContents(
+                    uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+                ),
+            )
+        )
+    return results
 
 
-async def handle_list_schemas(arguments, db, *_, exclusion_config=None):
+async def handle_list_schemas(arguments, db, *_, exclusion_config=None, exclude_json_results=False):
     if not arguments or "database" not in arguments:
         raise ValueError("Missing required 'database' parameter")
 
@@ -115,16 +118,20 @@ async def handle_list_schemas(arguments, db, *_, exclusion_config=None):
     }
     yaml_output = to_yaml(output)
     json_output = to_json(output)
-    return [
-        types.TextContent(type="text", text=yaml_output),
-        types.EmbeddedResource(
-            type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
-        ),
-    ]
+    results: list[ResponseType] = [types.TextContent(type="text", text=yaml_output)]
+    if not exclude_json_results:
+        results.append(
+            types.EmbeddedResource(
+                type="resource",
+                resource=types.TextResourceContents(
+                    uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+                ),
+            )
+        )
+    return results
 
 
-async def handle_list_tables(arguments, db, *_, exclusion_config=None):
+async def handle_list_tables(arguments, db, *_, exclusion_config=None, exclude_json_results=False):
     if not arguments or "database" not in arguments or "schema" not in arguments:
         raise ValueError("Missing required 'database' and 'schema' parameters")
 
@@ -161,16 +168,20 @@ async def handle_list_tables(arguments, db, *_, exclusion_config=None):
     }
     yaml_output = to_yaml(output)
     json_output = to_json(output)
-    return [
-        types.TextContent(type="text", text=yaml_output),
-        types.EmbeddedResource(
-            type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
-        ),
-    ]
+    results: list[ResponseType] = [types.TextContent(type="text", text=yaml_output)]
+    if not exclude_json_results:
+        results.append(
+            types.EmbeddedResource(
+                type="resource",
+                resource=types.TextResourceContents(
+                    uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+                ),
+            )
+        )
+    return results
 
 
-async def handle_describe_table(arguments, db, *_):
+async def handle_describe_table(arguments, db, *_, exclude_json_results=False):
     if not arguments or "table_name" not in arguments:
         raise ValueError("Missing table_name argument")
 
@@ -202,16 +213,20 @@ async def handle_describe_table(arguments, db, *_):
     }
     yaml_output = to_yaml(output)
     json_output = to_json(output)
-    return [
-        types.TextContent(type="text", text=yaml_output),
-        types.EmbeddedResource(
-            type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
-        ),
-    ]
+    results: list[ResponseType] = [types.TextContent(type="text", text=yaml_output)]
+    if not exclude_json_results:
+        results.append(
+            types.EmbeddedResource(
+                type="resource",
+                resource=types.TextResourceContents(
+                    uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+                ),
+            )
+        )
+    return results
 
 
-async def handle_read_query(arguments, db, write_detector, *_):
+async def handle_read_query(arguments, db, write_detector, *_, exclude_json_results=False):
     if not arguments or "query" not in arguments:
         raise ValueError("Missing query argument")
 
@@ -227,16 +242,20 @@ async def handle_read_query(arguments, db, write_detector, *_):
     }
     yaml_output = to_yaml(output)
     json_output = to_json(output)
-    return [
-        types.TextContent(type="text", text=yaml_output),
-        types.EmbeddedResource(
-            type="resource",
-            resource=types.TextResourceContents(uri=f"data://{data_id}", text=json_output, mimeType="application/json"),
-        ),
-    ]
+    results: list[ResponseType] = [types.TextContent(type="text", text=yaml_output)]
+    if not exclude_json_results:
+        results.append(
+            types.EmbeddedResource(
+                type="resource",
+                resource=types.TextResourceContents(
+                    uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+                ),
+            )
+        )
+    return results
 
 
-async def handle_append_insight(arguments, db, _, __, server):
+async def handle_append_insight(arguments, db, _, __, server, exclude_json_results=False):
     if not arguments or "insight" not in arguments:
         raise ValueError("Missing insight argument")
 
@@ -245,7 +264,7 @@ async def handle_append_insight(arguments, db, _, __, server):
     return [types.TextContent(type="text", text="Insight added to memo")]
 
 
-async def handle_write_query(arguments, db, _, allow_write, __):
+async def handle_write_query(arguments, db, _, allow_write, __, **___):
     if not allow_write:
         raise ValueError("Write operations are not allowed for this data connection")
     if arguments["query"].strip().upper().startswith("SELECT"):
@@ -255,7 +274,7 @@ async def handle_write_query(arguments, db, _, allow_write, __):
     return [types.TextContent(type="text", text=str(results))]
 
 
-async def handle_create_table(arguments, db, _, allow_write, __):
+async def handle_create_table(arguments, db, _, allow_write, __, **___):
     if not allow_write:
         raise ValueError("Write operations are not allowed for this data connection")
     if not arguments["query"].strip().upper().startswith("CREATE TABLE"):
@@ -306,6 +325,7 @@ async def main(
     exclude_tools: list[str] = [],
     config_file: str = "runtime_config.json",
     exclude_patterns: dict = None,
+    exclude_json_results: bool = False,
 ):
     # Setup logging
     if log_dir:
@@ -517,9 +537,7 @@ async def main(
 
     @server.call_tool()
     @handle_tool_errors
-    async def handle_call_tool(
-        name: str, arguments: dict[str, Any] | None
-    ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
+    async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[ResponseType]:
         if name in exclude_tools:
             return [types.TextContent(type="text", text=f"Tool {name} is excluded from this data connection")]
 
@@ -536,9 +554,17 @@ async def main(
                 allow_write,
                 server,
                 exclusion_config=exclusion_config,
+                exclude_json_results=exclude_json_results,
             )
         else:
-            return await handler(arguments, db, write_detector, allow_write, server)
+            return await handler(
+                arguments,
+                db,
+                write_detector,
+                allow_write,
+                server,
+                exclude_json_results=exclude_json_results,
+            )
 
     @server.list_tools()
     async def handle_list_tools() -> list[types.Tool]:


### PR DESCRIPTION
This pull request introduces a new command-line option, `--exclude-json-results`, to provide more control over the verbosity of the server's output.

### Motivation

Currently, the server returns query results in both YAML and JSON formats for each tool call. While this provides flexibility, the duplication of data can rapidly consume the context window of a large language model. By returning data in two formats, we effectively double the number of tokens used for each response, leading to increased costs and faster context window saturation.

### Implementation

To address this, the `--exclude-json-results` flag has been added. When this flag is present, the server will suppress the `EmbeddedResource` JSON output and only return the YAML representation of the data. This change has been implemented by:

*   Adding the `--exclude-json-results` argument to `__init__.py`.
*   Updating the tool handlers in `server.py` to conditionally append the `EmbeddedResource` based on this flag.
*   Ensuring that all tool handler function signatures are compatible with the new argument.

### Benefit

By allowing users to exclude the JSON output, this change offers a simple yet effective way to manage token consumption, making interactions with the server more efficient and cost-effective, especially in long-running sessions or when dealing with large datasets.
