### PR TITLE
Evolution: Add private_key as optional param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ COPY README.md .
 COPY runtime_config.json .
 COPY src/ src/
 
+# Install required packages for private key authentication
+RUN pip install --no-cache-dir \
+    cryptography \
+    python-dotenv \
+    snowflake-connector-python \
+    snowflake-snowpark-python
+
 # Install project dependencies
 RUN pip install --no-cache-dir .
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ npx -y @smithery/cli install mcp_snowflake_server --client claude
       "--role", "your_role",
       "--database", "your_database",
       "--schema", "your_schema"
+      // Optionally: "--private_key_path", "your_private_key_absolute_path"
       // Optionally: "--allow_write"
       // Optionally: "--log_dir", "/absolute/path/to/logs"
       // Optionally: "--log_level", "DEBUG"/"INFO"/"WARNING"/"ERROR"/"CRITICAL"
@@ -143,6 +144,8 @@ SNOWFLAKE_DATABASE="xxx"
 SNOWFLAKE_SCHEMA="xxx"
 SNOWFLAKE_WAREHOUSE="xxx"
 SNOWFLAKE_PASSWORD="xxx"
+SNOWFLAKE_PASSWORD="xxx"
+SNOWFLAKE_PRIVATE_KEY_PATH=/absolute/path/key.p8
 # Alternatively, use external browser authentication:
 # SNOWFLAKE_AUTHENTICATOR="externalbrowser"
 ```

--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -37,6 +37,11 @@ def parse_args():
         nargs="+",
         help="List of tools to exclude",
     )
+    parser.add_argument(
+        "--private_key_path",
+        required=False,
+        help="Path to private key file for authentication",
+    )
 
     # First, get all the arguments we don't know about
     args, unknown = parser.parse_known_args()
@@ -66,6 +71,10 @@ def parse_args():
         "exclude_tools": args.exclude_tools,
     }
 
+    # Add private_key_path if provided
+    if args.private_key_path:
+        connection_args["private_key_path"] = args.private_key_path
+
     return server_args, connection_args
 
 
@@ -81,6 +90,11 @@ def main():
         for k in default_connection_args
         if os.getenv("SNOWFLAKE_" + k.upper()) is not None
     }
+
+    # Add private key path from environment if available
+    private_key_path = os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH")
+    if private_key_path:
+        connection_args_from_env["private_key_path"] = private_key_path
 
     server_args, connection_args = parse_args()
 

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -28,6 +28,25 @@ class SnowflakeDB:
     async def _init_database(self):
         """Initialize connection to the Snowflake database"""
         try:
+            # Handle private key authentication
+            if "private_key_path" in self.connection_config:
+                from cryptography.hazmat.primitives import serialization
+                with open(self.connection_config["private_key_path"], "rb") as key_file:
+                    p_key = serialization.load_pem_private_key(
+                        key_file.read(),
+                        password=None  # If your key is password protected, you'll need to provide it
+                    )
+                    
+                pkb = p_key.private_bytes(
+                    encoding=serialization.Encoding.DER,
+                    format=serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=serialization.NoEncryption()
+                )
+                
+                # Replace private_key_path with the actual key content
+                self.connection_config["private_key"] = pkb
+                del self.connection_config["private_key_path"]
+            
             # Create session without setting specific database and schema
             self.session = Session.builder.configs(self.connection_config).create()
 


### PR DESCRIPTION
I have a private key in snowflake, no password is allowed. 

I need to install some dependencies in the dockerfile as the key has to be passed directly, you cant pass a path. 

And im making it optional, as to preserve the previous functionality of the other passwords 


![image](https://github.com/user-attachments/assets/665d0bce-3035-4390-b2e7-53bc3bc2e528)
