### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "mcp>=1.0.0",
-    "snowflake-connector-python[pandas]>=3.12.0,<3.14.0",
+    "snowflake-connector-python[pandas]>=3.15.0",
     "pandas>=2.2.3",
     "python-dotenv>=1.0.1",
     "sqlparse>=0.5.3",


### PR DESCRIPTION
After recent updates in OpenSSL the MCP server is broken:

`AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?`

Easy fix is to use snowflake connector >= 3.15.0