### PR TITLE
Add ability to use RSA key with passphrase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ uv.lock
 src/mcp_snowflake_server/__pycache__
 **/.DS_Store
 # dist
+
+connections.toml

--- a/example_connections.toml
+++ b/example_connections.toml
@@ -41,6 +41,7 @@ role = "ANALYTICS_ROLE"
 account = "your_account_id"
 user = "reporting_user"
 private_key_path = "/path/to/private_key.pem"  # Using key-pair authentication
+private_key_passphrase = "your_private_key_passphrase" # Optional, if your key is encrypted
 warehouse = "REPORTING_WH"
 database = "REPORTING_DB"
 schema = "REPORTS"

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -32,21 +32,23 @@ class SnowflakeDB:
             if "private_key_path" in self.connection_config:
                 from cryptography.hazmat.primitives import serialization
                 with open(self.connection_config["private_key_path"], "rb") as key_file:
+                    passphrase = self.connection_config.get("private_key_passphrase", None)
+
                     p_key = serialization.load_pem_private_key(
                         key_file.read(),
-                        password=None  # If your key is password protected, you'll need to provide it
+                        password=passphrase.encode() if passphrase else None,
                     )
-                    
+
                 pkb = p_key.private_bytes(
                     encoding=serialization.Encoding.DER,
                     format=serialization.PrivateFormat.PKCS8,
                     encryption_algorithm=serialization.NoEncryption()
                 )
-                
+
                 # Replace private_key_path with the actual key content
                 self.connection_config["private_key"] = pkb
                 del self.connection_config["private_key_path"]
-            
+
             # Create session without setting specific database and schema
             self.session = Session.builder.configs(self.connection_config).create()
 


### PR DESCRIPTION
My RSA keys are all encrypted. This adds the ability to have both an encrypted or unencrypted RSA key.

Also:

- Updates `.gitignore` to ignore the local `connections.toml`
- Updates the `example_connections.toml` to use the passphrase key