### PR TITLE
Add where clause support to compare_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The server offers six core tools:
   - Triggers update of memo://insights resource
 
 
-## Usage Locally with `Claude Desktop` or `Cursor`
+## Local Usage with `Claude Desktop` or `Cursor`
 
 Below is a quick guide to get started, and a more general and detailed guide can be found [here](https://modelcontextprotocol.io/quickstart/user). 
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ The server offers six core tools:
   - Triggers update of memo://insights resource
 
 
-## Usage Locally with Claude Desktop
+## Usage Locally with `Claude Desktop` or `Cursor`
 
 Below is a quick guide to get started, and a more general and detailed guide can be found [here](https://modelcontextprotocol.io/quickstart/user). 
 
 
-1. Install [Claude AI Desktop App](https://claude.ai/download)
+1. Install [Claude AI Desktop App](https://claude.ai/download) or [Cursor](https://www.cursor.com/downloads)
 
 2. Install `uv` by:
 ```
@@ -99,7 +99,7 @@ SNOWFLAKE_AUTHENTICATOR="externalbrowser"  # Use Okta for authentication
 uv --directory /absolute/path/to/mcp_snowflake_server run mcp_snowflake_server
 ```
 
-6. Add the server to your `claude_desktop_config.json` (Claude -> Settings -> Developer -> Edit Config)
+6. To use `Claude Desktop`: add the server to your `claude_desktop_config.json` (Claude -> Settings -> Developer -> Edit Config), then restart Claude Desktop.
 ```python
 "mcpServers": {
   "snowflake_local": {
@@ -116,4 +116,8 @@ uv --directory /absolute/path/to/mcp_snowflake_server run mcp_snowflake_server
       ]
   }
 }
+```
+7. To use `Cursor`: add the following to your Curser Settings -> MCP -> Add new MCP server -> Command
+```
+/absolute/path/to/uv --directory /absolute/path/to/mcp_snowflake_server run mcp_snowflake_server
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The server exposes a single dynamic resource:
   - Auto-updates as new insights are discovered via the append-insight tool
 
 ### Tools
-The server offers six core tools:
+The server offers these core tools:
 
 #### Query Tools
 - `read_query`
@@ -61,6 +61,14 @@ The server offers six core tools:
   - Returns: Array of column definitions with names and types
 
 #### Analysis Tools
+- `compare_models`
+  - Compare two tables or models and report summary statistics and differing rows
+  - Input:
+    - `base_model` (string): Fully qualified base table name (e.g., `database.schema.table`)
+    - `comparing_model` (string): Fully qualified comparing table name (e.g., `database.schema.table`)
+    - `where_clause` (string, optional): SQL condition applied to both models before comparison, with or without the `WHERE` keyword
+  - Returns: Comparison summary and preview of differing rows
+
 - `append_insight`
   - Add new data insights to the memo resource
   - Input:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "mcp>=1.0.0",
-    "snowflake-connector-python[pandas]>=3.13.2",
+    "snowflake-connector-python[pandas,secure-local-storage]>=3.13.2",
     "pandas>=2.2.3",
     "python-dotenv>=1.0.1",
     "sqlparse>=0.5.3",

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -4,8 +4,7 @@
       "ci",
       "backup",
       "temp",
-      "test",
-      "dev"
+      "test"
     ],
     "schemas": [
       "backup",
@@ -13,8 +12,7 @@
       "temp",
       "tmp",
       "test",
-      "staging",
-      "information_schema"
+      "staging"
     ],
     "tables": [
       "backup",
@@ -22,9 +20,7 @@
       "tmp",
       "temp",
       "test",
-      "copy",
-      "old",
-      "archive"
+      "copy"
     ]
   }
 }

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -1,7 +1,6 @@
 {
   "exclude_patterns": {
     "databases": [
-      "build",
       "ci",
       "backup",
       "temp",
@@ -15,7 +14,6 @@
       "tmp",
       "test",
       "staging",
-      "util",
       "information_schema"
     ],
     "tables": [

--- a/src/mcp_snowflake_server/server.py
+++ b/src/mcp_snowflake_server/server.py
@@ -62,12 +62,30 @@ class SnowflakeDB:
         logger.debug(f"Executing query: {query}")
         try:
             result = self.session.sql(query).to_pandas()
-            # Convert date and datetime columns to ISO format strings
+            
+            # Convert all timestamp/date columns to ISO format strings for JSON serialization
             for col in result.columns:
                 if result[col].dtype == 'datetime64[ns]':
                     result[col] = result[col].dt.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-                elif result[col].dtype == 'object' and result[col].apply(lambda x: isinstance(x, (datetime.date, datetime.datetime))).any():
-                    result[col] = result[col].apply(lambda x: x.isoformat() if x is not None else None)
+                elif result[col].dtype == 'object':
+                    # Handle various timestamp/date types that might be in object columns
+                    def convert_timestamp(x):
+                        if x is None:
+                            return None
+                        elif isinstance(x, (datetime.date, datetime.datetime)):
+                            return x.isoformat()
+                        elif hasattr(x, 'isoformat'):  # Handle Snowflake Timestamp objects
+                            return x.isoformat()
+                        elif hasattr(x, 'strftime'):  # Handle other date-like objects
+                            try:
+                                return x.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                            except:
+                                return str(x)
+                        else:
+                            return x
+                    
+                    result[col] = result[col].apply(convert_timestamp)
+            
             result_rows = result.to_dict(orient="records")
             data_id = str(uuid.uuid4())
 
@@ -119,6 +137,55 @@ class Tool(BaseModel):
         list[types.TextContent | types.ImageContent | types.EmbeddedResource],
     ]
     tags: list[str] = []
+
+
+def normalize_identifier_part(part: str) -> tuple[str, str]:
+    """Normalize an identifier part and determine the value to use for metadata lookups."""
+
+    stripped = part.strip()
+    if stripped.startswith("\"") and stripped.endswith("\"") and len(stripped) >= 2:
+        # Remove surrounding quotes and unescape any embedded quotes
+        unquoted = stripped[1:-1].replace("\"\"", "\"")
+        return unquoted, unquoted
+    return stripped, stripped.upper()
+
+
+def parse_table_identifier(table_spec: str) -> tuple[list[str], list[str]]:
+    """Split a fully qualified table name into parts and metadata-safe variants."""
+
+    parts = [part for part in table_spec.split(".") if part.strip()]
+    if len(parts) != 3:
+        raise ValueError("Table name must be fully qualified as 'database.schema.table'")
+
+    normalized_parts: list[str] = []
+    metadata_parts: list[str] = []
+    for part in parts:
+        normalized, metadata = normalize_identifier_part(part)
+        normalized_parts.append(normalized)
+        metadata_parts.append(metadata)
+
+    return normalized_parts, metadata_parts
+
+
+def escape_literal(value: str) -> str:
+    """Escape string literals for inclusion in SQL queries."""
+
+    return value.replace("'", "''")
+
+
+def fetch_table_columns(db: SnowflakeDB, metadata_parts: list[str]) -> list[str]:
+    """Fetch ordered column names for a given table using information_schema."""
+
+    database, schema, table = metadata_parts
+    query = f"""
+        SELECT COLUMN_NAME
+        FROM {database}.INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = '{escape_literal(schema)}'
+          AND TABLE_NAME = '{escape_literal(table)}'
+        ORDER BY ORDINAL_POSITION
+    """
+    data, _ = db.execute_query(query)
+    return [row["COLUMN_NAME"] for row in data]
 
 
 # Tool handlers
@@ -208,7 +275,7 @@ async def handle_list_tables(arguments, db, *_, exclusion_config=None):
 
     query = f"""
         SELECT table_catalog, table_schema, table_name, comment 
-        FROM {database}.information_schema.tables 
+        FROM {database.upper()}.information_schema.tables 
         WHERE table_schema = '{schema.upper()}'
     """
     data, data_id = db.execute_query(query)
@@ -285,6 +352,195 @@ async def handle_describe_table(arguments, db, *_):
             type="resource",
             resource=types.TextResourceContents(
                 uri=f"data://{data_id}", text=json_output, mimeType="application/json"
+            ),
+        ),
+    ]
+
+
+async def handle_compare_models(arguments, db, *_):
+    if not arguments:
+        raise ValueError("Missing required arguments: base_model and comparing_model")
+
+    if "base_model" not in arguments or "comparing_model" not in arguments:
+        raise ValueError("Missing required arguments: base_model and comparing_model")
+
+    base_model = arguments["base_model"]
+    comparing_model = arguments["comparing_model"]
+    column_source = arguments.get("column_source", "base").lower()
+
+    if column_source not in {"base", "comparing"}:
+        raise ValueError("column_source must be either 'base' or 'comparing'")
+
+    preview_limit_arg = arguments.get("preview_limit", 30)
+    try:
+        preview_limit = int(preview_limit_arg)
+    except (TypeError, ValueError):
+        raise ValueError("preview_limit must be an integer")
+
+    if preview_limit <= 0:
+        raise ValueError("preview_limit must be greater than 0")
+
+    except_columns_arg = arguments.get("except_columns", [])
+    if isinstance(except_columns_arg, str):
+        except_columns = [except_columns_arg]
+    else:
+        except_columns = list(except_columns_arg)
+
+    base_parts, base_metadata_parts = parse_table_identifier(base_model)
+    compare_parts, compare_metadata_parts = parse_table_identifier(comparing_model)
+
+    base_columns = fetch_table_columns(db, base_metadata_parts)
+    compare_columns = fetch_table_columns(db, compare_metadata_parts)
+
+    source_columns = base_columns if column_source == "base" else compare_columns
+    exceptions = {col.upper() for col in except_columns}
+    selected_columns = [col for col in source_columns if col.upper() not in exceptions]
+
+    if not selected_columns:
+        raise ValueError("No columns available for comparison after applying exceptions")
+
+    base_column_set = {col.upper() for col in base_columns}
+    compare_column_set = {col.upper() for col in compare_columns}
+
+    missing_in_base = [col for col in selected_columns if col.upper() not in base_column_set]
+    missing_in_compare = [col for col in selected_columns if col.upper() not in compare_column_set]
+
+    if missing_in_base:
+        raise ValueError(
+            "Selected columns are not present in the base model: " + ", ".join(missing_in_base)
+        )
+    if missing_in_compare:
+        raise ValueError(
+            "Selected columns are not present in the comparing model: "
+            + ", ".join(missing_in_compare)
+        )
+
+    column_list = ", ".join(selected_columns)
+
+    base_fqn = ".".join(part.upper() for part in base_parts)
+    compare_fqn = ".".join(part.upper() for part in compare_parts)
+
+    base_cte = f"""
+WITH base_model AS (
+    SELECT {column_list}
+    FROM {base_fqn}
+),
+compare_model AS (
+    SELECT {column_list}
+    FROM {compare_fqn}
+)"""
+
+    stats_query = f"""
+{base_cte},
+base_counts AS (SELECT COUNT(*) AS base_row_count FROM base_model),
+compare_counts AS (SELECT COUNT(*) AS compare_row_count FROM compare_model),
+base_only AS (
+    SELECT {column_list}
+    FROM base_model
+    MINUS
+    SELECT {column_list}
+    FROM compare_model
+),
+compare_only AS (
+    SELECT {column_list}
+    FROM compare_model
+    MINUS
+    SELECT {column_list}
+    FROM base_model
+),
+base_only_count AS (SELECT COUNT(*) AS base_only_count FROM base_only),
+compare_only_count AS (SELECT COUNT(*) AS compare_only_count FROM compare_only),
+matching AS (
+    SELECT COUNT(*) AS matching_row_count
+    FROM (
+        SELECT * FROM base_model
+        INTERSECT
+        SELECT * FROM compare_model
+    )
+)
+SELECT
+    base_counts.base_row_count,
+    compare_counts.compare_row_count,
+    matching.matching_row_count,
+    base_only_count.base_only_count,
+    compare_only_count.compare_only_count,
+    base_only_count.base_only_count + compare_only_count.compare_only_count AS differing_row_count
+FROM base_counts, compare_counts, matching, base_only_count, compare_only_count
+"""
+
+    diff_query = f"""
+{base_cte},
+diff_compare_only AS (
+    SELECT 'in_comparing_not_base' AS difference_type, {column_list}
+    FROM compare_model
+    MINUS
+    SELECT 'in_comparing_not_base' AS difference_type, {column_list}
+    FROM base_model
+),
+diff_base_only AS (
+    SELECT 'in_base_not_comparing' AS difference_type, {column_list}
+    FROM base_model
+    MINUS
+    SELECT 'in_base_not_comparing' AS difference_type, {column_list}
+    FROM compare_model
+)
+SELECT *
+FROM diff_compare_only
+UNION ALL
+SELECT *
+FROM diff_base_only
+ORDER BY 1, 2
+LIMIT {preview_limit}
+"""
+
+    stats_data, stats_data_id = db.execute_query(stats_query)
+    differences_data, differences_data_id = db.execute_query(diff_query)
+
+    stats_row = stats_data[0] if stats_data else {}
+
+    summary_output = {
+        "type": "model_comparison_summary",
+        "base_model": base_model,
+        "comparing_model": comparing_model,
+        "column_source": column_source,
+        "columns_compared": selected_columns,
+        "except_columns": except_columns,
+        "stats_data_id": stats_data_id,
+        "statistics": stats_row,
+        "differences_data_id": differences_data_id,
+        "differences_preview_count": len(differences_data),
+        "differences_preview_limit": preview_limit,
+    }
+
+    summary_yaml = data_to_yaml(summary_output)
+    summary_json = json.dumps(summary_output)
+    differences_output = {
+        "type": "model_comparison_differences",
+        "data_id": differences_data_id,
+        "base_model": base_model,
+        "comparing_model": comparing_model,
+        "difference_rows": differences_data,
+        "preview_limit": preview_limit,
+        "preview_count": len(differences_data),
+    }
+    differences_json = json.dumps(differences_output)
+
+    return [
+        types.TextContent(type="text", text=summary_yaml),
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.TextResourceContents(
+                uri=f"data://{stats_data_id}",
+                text=summary_json,
+                mimeType="application/json",
+            ),
+        ),
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.TextResourceContents(
+                uri=f"data://{differences_data_id}",
+                text=differences_json,
+                mimeType="application/json",
             ),
         ),
     ]
@@ -458,6 +714,43 @@ async def main(
                 "required": ["table_name"],
             },
             handler=handle_describe_table,
+        ),
+        Tool(
+            name="compare_models",
+            description="Compare two models or tables and report summary statistics and differences",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "base_model": {
+                        "type": "string",
+                        "description": "Fully qualified table name for the base model (database.schema.table)",
+                    },
+                    "comparing_model": {
+                        "type": "string",
+                        "description": "Fully qualified table name for the comparing model (database.schema.table)",
+                    },
+                    "column_source": {
+                        "type": "string",
+                        "description": "Which model's columns to use for comparison (base or comparing)",
+                        "enum": ["base", "comparing"],
+                        "default": "base",
+                    },
+                    "preview_limit": {
+                        "type": "integer",
+                        "description": "Maximum number of differing rows to include in the preview",
+                        "default": 30,
+                        "minimum": 1,
+                    },
+                    "except_columns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional list of column names to exclude from the comparison",
+                        "default": [],
+                    },
+                },
+                "required": ["base_model", "comparing_model"],
+            },
+            handler=handle_compare_models,
         ),
         Tool(
             name="read_query",

--- a/src/mcp_snowflake_server/server.py
+++ b/src/mcp_snowflake_server/server.py
@@ -221,6 +221,29 @@ def escape_literal(value: str) -> str:
     return value.replace("'", "''")
 
 
+def normalize_where_clause(where_clause: str | None) -> str:
+    """Normalize an optional SQL WHERE clause fragment."""
+
+    if where_clause is None:
+        return ""
+    if not isinstance(where_clause, str):
+        raise ValueError("where_clause must be a string")
+
+    normalized = where_clause.strip()
+    if not normalized:
+        return ""
+
+    if normalized.upper() == "WHERE":
+        raise ValueError("where_clause must include a condition")
+    if normalized.upper().startswith("WHERE "):
+        normalized = normalized[6:].strip()
+
+    if ";" in normalized:
+        raise ValueError("where_clause must not contain semicolons")
+
+    return normalized
+
+
 def fetch_table_columns(db: SnowflakeDB, metadata_parts: list[str]) -> list[str]:
     """Fetch ordered column names for a given table using information_schema."""
 
@@ -450,6 +473,7 @@ async def handle_compare_models(arguments, db, *_):
     base_model = arguments["base_model"]
     comparing_model = arguments["comparing_model"]
     column_source = arguments.get("column_source", "base").lower()
+    where_clause = normalize_where_clause(arguments.get("where_clause"))
 
     if column_source not in {"base", "comparing"}:
         raise ValueError("column_source must be either 'base' or 'comparing'")
@@ -482,6 +506,7 @@ async def handle_compare_models(arguments, db, *_):
         column_list = [column_list_arg]
     else:
         column_list = list(column_list_arg)
+    column_list_provided = bool(column_list)
 
     base_parts, base_metadata_parts = parse_table_identifier(base_model)
     compare_parts, compare_metadata_parts = parse_table_identifier(comparing_model)
@@ -519,26 +544,27 @@ async def handle_compare_models(arguments, db, *_):
             + ", ".join(missing_in_compare)
         )
 
-    column_list = ", ".join(selected_columns)
+    column_sql = ", ".join(selected_columns)
 
     base_fqn = ".".join(part.upper() for part in base_parts)
     compare_fqn = ".".join(part.upper() for part in compare_parts)
+    where_sql = f"\n    WHERE {where_clause}" if where_clause else ""
 
     base_cte = f"""
 WITH base_model AS (
-    SELECT {column_list}
-    FROM {base_fqn}
+    SELECT {column_sql}
+    FROM {base_fqn}{where_sql}
 ),
 compare_model AS (
-    SELECT {column_list}
-    FROM {compare_fqn}
+    SELECT {column_sql}
+    FROM {compare_fqn}{where_sql}
 )"""
 
     # Sample some rows to estimate size and calculate dynamic limit
     sample_query = f"""
 {base_cte},
 sample_rows AS (
-    SELECT {column_list}
+    SELECT {column_sql}
     FROM base_model
     LIMIT 5
 )
@@ -562,17 +588,17 @@ SELECT * FROM sample_rows
 base_counts AS (SELECT COUNT(*) AS base_row_count FROM base_model),
 compare_counts AS (SELECT COUNT(*) AS compare_row_count FROM compare_model),
 base_only AS (
-    SELECT {column_list}
+    SELECT {column_sql}
     FROM base_model
     MINUS
-    SELECT {column_list}
+    SELECT {column_sql}
     FROM compare_model
 ),
 compare_only AS (
-    SELECT {column_list}
+    SELECT {column_sql}
     FROM compare_model
     MINUS
-    SELECT {column_list}
+    SELECT {column_sql}
     FROM base_model
 ),
 base_only_count AS (SELECT COUNT(*) AS base_only_count FROM base_only),
@@ -598,17 +624,17 @@ FROM base_counts, compare_counts, matching, base_only_count, compare_only_count
     diff_query = f"""
 {base_cte},
 diff_compare_only AS (
-    SELECT 'in_comparing_not_base' AS difference_type, {column_list}
+    SELECT 'in_comparing_not_base' AS difference_type, {column_sql}
     FROM compare_model
     MINUS
-    SELECT 'in_comparing_not_base' AS difference_type, {column_list}
+    SELECT 'in_comparing_not_base' AS difference_type, {column_sql}
     FROM base_model
 ),
 diff_base_only AS (
-    SELECT 'in_base_not_comparing' AS difference_type, {column_list}
+    SELECT 'in_base_not_comparing' AS difference_type, {column_sql}
     FROM base_model
     MINUS
-    SELECT 'in_base_not_comparing' AS difference_type, {column_list}
+    SELECT 'in_base_not_comparing' AS difference_type, {column_sql}
     FROM compare_model
 )
 SELECT *
@@ -629,10 +655,11 @@ LIMIT {effective_limit}
         "type": "model_comparison_summary",
         "base_model": base_model,
         "comparing_model": comparing_model,
-        "column_source": column_source if not column_list else None,
+        "where_clause": where_clause or None,
+        "column_source": column_source if not column_list_provided else None,
         "columns_compared": selected_columns,
-        "column_list_provided": bool(column_list),
-        "except_columns": except_columns if not column_list else [],
+        "column_list_provided": column_list_provided,
+        "except_columns": except_columns if not column_list_provided else [],
         "stats_data_id": stats_data_id,
         "statistics": stats_row,
         "differences_data_id": differences_data_id,
@@ -649,6 +676,7 @@ LIMIT {effective_limit}
         "data_id": differences_data_id,
         "base_model": base_model,
         "comparing_model": comparing_model,
+        "where_clause": where_clause or None,
         "difference_rows": differences_data,
         "preview_limit": effective_limit,
         "user_specified_limit": preview_limit,
@@ -859,6 +887,10 @@ async def main(
                     "comparing_model": {
                         "type": "string",
                         "description": "Fully qualified table name for the comparing model (database.schema.table)",
+                    },
+                    "where_clause": {
+                        "type": "string",
+                        "description": "Optional SQL WHERE condition applied to both models before comparison. May include or omit the WHERE keyword. Semicolons are not allowed.",
                     },
                     "column_source": {
                         "type": "string",


### PR DESCRIPTION
## Summary
- Add optional `where_clause` support to `compare_models`, applied to both model CTEs before comparison
- Normalize clauses with or without a leading `WHERE` and reject semicolons
- Include the applied filter in comparison outputs and document the new parameter

## Test plan
- `python -m py_compile src/mcp_snowflake_server/server.py`
- `git diff --check`
- `uv run pyright` *(fails on existing repository type errors unrelated to this change)*